### PR TITLE
Improve input codec templating

### DIFF
--- a/src/cr_kyoushi/dataset/config.py
+++ b/src/cr_kyoushi/dataset/config.py
@@ -123,7 +123,7 @@ class LogstashLogConfig(BaseModel):
         ...,
         description="The type to tag the log input with.",
     )
-    codec: str = Field(
+    codec: Union[str, Dict[str, Any]] = Field(
         "plain",
         description="The file codec to use for reading.",
     )

--- a/src/cr_kyoushi/dataset/config.py
+++ b/src/cr_kyoushi/dataset/config.py
@@ -123,7 +123,7 @@ class LogstashLogConfig(BaseModel):
         ...,
         description="The type to tag the log input with.",
     )
-    codec: Union[str, Dict[str, Any]] = Field(
+    codec: Union[str, Dict[str, Dict[str, Any]]] = Field(
         "plain",
         description="The file codec to use for reading.",
     )

--- a/src/cr_kyoushi/dataset/templates/input.conf.j2
+++ b/src/cr_kyoushi/dataset/templates/input.conf.j2
@@ -16,7 +16,7 @@ input {
         }
 {%- else %}
         codec => "{{ log.codec }}"
-{% endif %}
+{%- endif %}
 {%- if log.path is string %}
         path => "{{ DATASET_DIR.joinpath('gather',name,'logs', log.path) }}"
 {%- else %}

--- a/src/cr_kyoushi/dataset/templates/input.conf.j2
+++ b/src/cr_kyoushi/dataset/templates/input.conf.j2
@@ -11,7 +11,7 @@ input {
 {%- set _codec = log.codec.keys() | first %}
         codec => {{ _codec }} {
 {%- for _field,_value in log.codec[_codec].items() %}
-                "{{ _field }}" => {{ _value | tojson }}
+            "{{ _field }}" => {{ _value | tojson }}
 {%- endfor %}
         }
 {%- else %}

--- a/src/cr_kyoushi/dataset/templates/input.conf.j2
+++ b/src/cr_kyoushi/dataset/templates/input.conf.j2
@@ -7,7 +7,16 @@ input {
 {%- if log.type is not none %}
         type => "{{ log.type }}"
 {%- endif %}
+{%- if log.codec is mapping %}
+{%- set _codec = log.codec.keys() | first %}
+        codec => {{ _codec }} {
+{%- for _field,_value in log.codec[_codec].items() %}
+                "{{ _field }}" => {{ _value | tojson }}
+{%- endfor %}
+        }
+{%- else %}
         codec => "{{ log.codec }}"
+{% endif %}
 {%- if log.path is string %}
         path => "{{ DATASET_DIR.joinpath('gather',name,'logs', log.path) }}"
 {%- else %}


### PR DESCRIPTION
Logstash supports 2 types of codec configuration

1. just setting the codec name this will result in using the codecs default settings
2. using a named hash containting the setting values.

The new input template now supports both options, previously only 1. was supported.