### PR TITLE
Fix entrypoint script python package config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ exclude = '''
 '''
 
 [tool.poetry.scripts]
-cr-kyoushi-dataset = "kyoushi.dataset.cli:cli"
+cr-kyoushi-dataset = "cr_kyoushi.dataset.cli:cli"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
During the transition to github the cli script entrypoints python function mapping was configured with the incorrect package name.
This PR fixes this configuration.