### PR TITLE
Use keyword id args for elasticsearch api

### DIFF
--- a/src/cr_kyoushi/dataset/elasticsearch.py
+++ b/src/cr_kyoushi/dataset/elasticsearch.py
@@ -63,13 +63,13 @@ def search_eql(
     while result["is_running"]:
         result_id = result["id"]
         sleep(check_interval)
-        result = es.eql.get_status(result_id)
+        result = es.eql.get_status(id=result_id)
 
     # if result id is not none then we have a async request and have
     # to retrieve the actual result and delete the async data
     if result_id is not None:
-        result = es.eql.get(result_id)
+        result = es.eql.get(id=result_id)
         # delete the async request once we have its data
-        es.eql.delete(result_id)
+        es.eql.delete(id=result_id)
 
     return result["hits"]

--- a/src/cr_kyoushi/dataset/labels.py
+++ b/src/cr_kyoushi/dataset/labels.py
@@ -154,7 +154,9 @@ def create_kyoushi_scripts(
         }
     }
     es.put_script(
-        f"{dataset_name}_kyoushi_label_filter", body=filter_script, context="filter"
+        id=f"{dataset_name}_kyoushi_label_filter",
+        body=filter_script,
+        context="filter",
     )
 
     labels_field = {
@@ -165,7 +167,9 @@ def create_kyoushi_scripts(
     }
 
     es.put_script(
-        f"{dataset_name}_kyoushi_label_field", body=labels_field, context="field"
+        id=f"{dataset_name}_kyoushi_label_field",
+        body=labels_field,
+        context="field",
     )
 
 


### PR DESCRIPTION
The type hints of the new version of the elasticsearch python API requires us to use specify keywords instead of positional args.