### PR TITLE
Fixed Invalid cross-device link error

### DIFF
--- a/src/cr_kyoushi/dataset/utils.py
+++ b/src/cr_kyoushi/dataset/utils.py
@@ -166,7 +166,6 @@ def remove_first_lines(path: Union[Text, Path], n: int, inclusive=False):
         # now start the iterator at our new first line
         for line in original:
             temp.write(line)
-        temp_path = Path(temp.name)
     # replace old file with new file
     shutil.move(temp.name, path)
 


### PR DESCRIPTION
If the data-dir and /tmp are on different filesystems, the "process"-run
will throw the exception "Invalid cross-device link". This bug was fixed
by using shutil.move().