### PR TITLE
Increase JVM heap size settings

### DIFF
--- a/src/cr_kyoushi/dataset/files/jvm.options
+++ b/src/cr_kyoushi/dataset/files/jvm.options
@@ -3,8 +3,8 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 
--Xms1g
--Xmx1g
+-Xms4g
+-Xmx4g
 
 ################################################################
 ## Expert settings


### PR DESCRIPTION
This PR changes the default JVM heap size setting for the logstash parser from 1G to 4G.
With this the default config should support more demanding datasets.